### PR TITLE
Instructions modal should scroll when it's too tall for the viewport

### DIFF
--- a/src/ui/ArthrobotApp.css
+++ b/src/ui/ArthrobotApp.css
@@ -2,6 +2,12 @@ body {
   font-family: "Arvo","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
+
+body .modal {
+  /* patching bootstrap's modal overflow behavior */
+  overflow-y: auto;
+}
+
 .btn:focus, .btn:active, .btn:active:focus,
 *:focus,*:active,*:active:focus {
     outline: 0;


### PR DESCRIPTION
Should help with the instructions getting clipped like they do in this screenshoot
![clipped instructions](https://cloud.githubusercontent.com/assets/702878/5422740/ff94a2be-8260-11e4-9f24-f2cb7a2d7fb0.png)
